### PR TITLE
Fix eval error

### DIFF
--- a/git-subtree.sh
+++ b/git-subtree.sh
@@ -28,7 +28,7 @@ rejoin        merge the new branch back into HEAD
  options for 'add', 'merge', 'pull' and 'push'
 squash        merge subtree changes as a single commit
 "
-eval $(echo "$OPTS_SPEC" | git rev-parse --parseopt -- "$@" || echo exit $?)
+eval "$(echo "$OPTS_SPEC" | git rev-parse --parseopt -- "$@" || echo exit $?)"
 
 PATH=$PATH:$(git --exec-path)
 . git-sh-setup
@@ -554,7 +554,8 @@ cmd_split()
 	eval "$grl" |
 	while read rev parents; do
 		revcount=$(($revcount + 1))
-		say -n "$revcount/$revmax ($createcount)"
+		say -n "$revcount/$revmax ($createcount)
+"
 		debug "Processing commit: $rev"
 		exists=$(cache_get $rev)
 		if [ -n "$exists" ]; then


### PR DESCRIPTION
Since upgrading git above 1.7.1, I've been experiencing a syntax error because the eval string wasn't quoted. All I did was add some quotes. http://gist.github.com/577862

Cheers and thanks for the great script! 

PS: Sorry I had to close the other one. I forgot I was committing from my work account.
