### PR TITLE
Added check to ensure that split succeeds before trying to push

### DIFF
--- a/git-subtree.sh
+++ b/git-subtree.sh
@@ -703,7 +703,12 @@ cmd_push()
 	    repository=$1
 	    refspec=$2
 	    echo "git push using: " $repository $refspec
-	    git push $repository $(git subtree split --prefix=$prefix):refs/heads/$refspec
+	    rev=$(git subtree split --prefix=$prefix)
+	    if [ -n "$rev" ]; then
+	        git push $repository $rev:refs/heads/$refspec
+	    else
+	        die "Couldn't push, 'git subtree split' failed."
+	    fi
 	else
 	    die "'$dir' must already exist. Try 'git subtree add'."
 	fi


### PR DESCRIPTION
Currently, if the `git subtree split` portion of the `git subtree push` command fails for any reason (in my case it was a `fatal: bad object` error), then the push command will actually delete the remote branch because the ref now just starts with a colon! Unfortunately I lost one of my remote branches due to this.

This commit fixes that by only pushing if the split command returns a non-empty ref.
