### PR TITLE
Updated git-subtree.sh to handle annotated tags

### DIFF
--- a/git-subtree.sh
+++ b/git-subtree.sh
@@ -119,7 +119,7 @@ esac
 dir="$(dirname "$prefix/.")"
 
 if [ "$command" != "pull" -a "$command" != "add" -a "$command" != "push" ]; then
-	revs=$(git rev-parse $default --revs-only "$@") || exit $?
+	revs="$(git rev-parse $default --revs-only "$@")^{}" || exit $?
 	dirs="$(git rev-parse --no-revs --no-flags "$@")" || exit $?
 	if [ -n "$dirs" ]; then
 		die "Error: Use --prefix instead of bare filenames."
@@ -519,7 +519,7 @@ cmd_add_repository()
 
 cmd_add_commit()
 {
-	revs=$(git rev-parse $default --revs-only "$@") || exit $?
+	revs="$(git rev-parse $default --revs-only "$@")^{}" || exit $?
 	set -- $revs
 	rev="$1"
 	
@@ -580,7 +580,8 @@ cmd_split()
 	eval "$grl" |
 	while read rev parents; do
 		revcount=$(($revcount + 1))
-		say -n "$revcount/$revmax ($createcount)"
+		say -n "$revcount/$revmax ($createcount)
+"
 		debug "Processing commit: $rev"
 		exists=$(cache_get $rev)
 		if [ -n "$exists" ]; then
@@ -643,7 +644,7 @@ cmd_split()
 
 cmd_merge()
 {
-	revs=$(git rev-parse $default --revs-only "$@") || exit $?
+	revs="$(git rev-parse $default --revs-only "$@")^{}" || exit $?
 	ensure_clean
 	
 	set -- $revs


### PR DESCRIPTION
Command was using tag SHA1 key although it should dereference the tag for certain commit before running the 'git subtree pull'.

Below example that triggered the issue
# Pull older version of ofc_lib

> git subtree pull -P plesiosync_lib/ip/ofc_lib ofc_lib ofc_lib-v0.3 --squash -d 
> # Hack sub-project in super-project
> 
> xemacs -nw plesiosync_lib/ip/ofc_lib/src/overflowcontrol.vhdl
> git commit -am "testing hack" 
> # Pull latest ofc-lib
> 
> git subtree pull -P plesiosync_lib/ip/ofc_lib ofc_lib ofc_lib-v0.7 --squash -d 
> # Resolve conflict
> 
> git mergetool 
> git commit 
> # Check the commit id for ofc_lib
> 
> git subtree split -P plesiosync_lib/ip/ofc_lib 
> fatal: 7e5957c2b61a46221b9c02c43e1f9c3925eacb76 is not a valid 'commit' object
> Can't copy commit 2ff99337166eb08db236828cce4384430390a37c

The hash key in fatal line is the annotateg tag key and not the actual commit key.
