### PR TITLE
Add a bash completion script.

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,0 +1,25 @@
+#!bash
+#
+# bash completion support for Git subtree.
+#
+# To use this routine:
+#
+#    1) Make sure you have installed and configured the core Git completion script, which is required to make this script work;
+#    2) Copy this file to somewhere (e.g. ~/.git-subtree-completion.sh);
+#    3) Added the following line to your .bashrc:
+#        source ~/.git-subtree-completion.sh
+#
+
+_git_subtree ()
+{
+	local cur="${COMP_WORDS[COMP_CWORD]}"
+
+	if [ $COMP_CWORD -eq 2 ]; then
+		__gitcomp "add merge pull push split"
+		return
+	elif [ $COMP_CWORD -eq 3 ]; then
+		__gitcomp "--prefix="
+		return
+	fi
+	__gitcomp "$(__git_remotes)"
+}


### PR DESCRIPTION
This patch adds a bash completion script to git-subtree, using the functions defined in the official git core bash completion script.

This was tested with git 1.7.2.3.
